### PR TITLE
fix(INFRA-552): pack from rootDir

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ module.exports = {
   branches: ['master'],
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
-    ['@semantic-release/npm', { pkgRoot: 'dist/' }],
+    ['@semantic-release/npm', {}],
     [
       '@semantic-release/github',
       {


### PR DESCRIPTION
Fixes publishing failure

I ran `npm pack` and confirmed the structure of the tarball