### PR TITLE
fix(INFRA-552): add missing .npmrc for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,5 @@ jobs:
         run: |
           yarn build
           npx semantic-release
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
           npm access grant read-only lifeomic:readonly-developers '@lifeomic/turbo-remote-cache'


### PR DESCRIPTION
Fixing [failed release workflow:](https://github.com/lifeomic/turbo-remote-cache/actions/runs/7413304094) 

PS: I thought I made the release workflow right, but this PR is a forgotten step.