### PR TITLE
test(INFRA-552): debug failed package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.LIFEOMIC_NPM_TOKEN }}
         run: |
           yarn build
-          npx semantic-release
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          npm token list
+          npx semantic-release
           npm access grant read-only lifeomic:readonly-developers '@lifeomic/turbo-remote-cache'


### PR DESCRIPTION
This is for dumping the token metadata to see if token is read-only. notice that it won't disclose the full token at all.