### PR TITLE
fix(INFRA-557): be able to run start-turbo-cache-server

### DIFF
--- a/bin/start_server.ts
+++ b/bin/start_server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import app from '../src/server';
 
 app.listen(41300);


### PR DESCRIPTION
when running `start-turbo-cache-server` I got:

```
root@ba0f115ece8c:~# start-turbo-cache-server 
/usr/local/bin/start-turbo-cache-server: line 1: use strict: command not found
/usr/local/bin/start-turbo-cache-server: line 2: syntax error near unexpected token `('
```

This PR is the fix