### PR TITLE
fix: correct token permissions for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     environment: npm
     env:
       FORCE_COLOR: 1


### PR DESCRIPTION
https://github.com/lifeomic/turbo-remote-cache/actions/runs/7589857713 failed b/c the token do not have access to github release.